### PR TITLE
Fix syntax error in ChessManager.gs

### DIFF
--- a/ChessManager.gs
+++ b/ChessManager.gs
@@ -936,6 +936,7 @@ function quickUpdate() {
   const username = getUsername();
   const results = [];
   try {
+    try {
     updateArchives();
     results.push('Archives updated');
   } catch (e) {
@@ -967,6 +968,9 @@ function quickUpdate() {
   }
   SpreadsheetApp.getActiveSpreadsheet().toast(results.join('\n'), 'Quick Update', 8);
   logExecution('quickUpdate', username, 'SUCCESS', new Date().getTime() - startMs, results.join(', '));
+  } catch (error) {
+    logExecution('quickUpdate', username, 'ERROR', new Date().getTime() - startMs, error.message);
+    throw error;
   } finally {
     try { lock.releaseLock(); } catch (e) {}
   }
@@ -979,6 +983,7 @@ function completeUpdate() {
   const username = getUsername();
   const results = [];
   try {
+    try {
     updateArchives();
     results.push('Archives updated');
   } catch (e) {
@@ -1010,6 +1015,9 @@ function completeUpdate() {
   }
   SpreadsheetApp.getActiveSpreadsheet().toast(results.join('\n'), 'Complete Update', 8);
   logExecution('completeUpdate', username, 'SUCCESS', new Date().getTime() - startMs, results.join(', '));
+  } catch (error) {
+    logExecution('completeUpdate', username, 'ERROR', new Date().getTime() - startMs, error.message);
+    throw error;
   } finally {
     try { lock.releaseLock(); } catch (e) {}
   }


### PR DESCRIPTION
Wrap `quickUpdate` and `completeUpdate` bodies in outer `try/catch` blocks to resolve "Unexpected token finally" syntax errors and ensure robust error logging and lock release.

---
<a href="https://cursor.com/background-agent?bcId=bc-03e39582-8f92-4c80-83f6-fc7d7f691f11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03e39582-8f92-4c80-83f6-fc7d7f691f11">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

